### PR TITLE
Text layout fixes on DataTable

### DIFF
--- a/ffa_app/lib/screens/home_screen.dart
+++ b/ffa_app/lib/screens/home_screen.dart
@@ -156,7 +156,10 @@ class _HomeScreenState extends State<HomeScreen> {
                             ),
                             for (final cell in row.columns.entries)
                               DataCell(
-                                Flexible(child: Text(cell.value.toString())),
+                                SizedBox(
+                                  width: 0,
+                                  child: Text(cell.value.toString()),
+                                ),
                               ),
                           ],
                         ),

--- a/ffa_app/lib/screens/home_screen.dart
+++ b/ffa_app/lib/screens/home_screen.dart
@@ -134,6 +134,7 @@ class _HomeScreenState extends State<HomeScreen> {
                       for (final x
                           in state.visibleAppEvents.first.columns.entries)
                         DataColumn(
+                          numeric: true,
                           label: Flexible(
                             child: Text(
                               switch (x.key) {
@@ -141,8 +142,7 @@ class _HomeScreenState extends State<HomeScreen> {
                                 "unique_users" => "Users",
                                 String x => x,
                               },
-                              maxLines: 2,
-                              overflow: TextOverflow.ellipsis,
+                              maxLines: 1,
                             ),
                           ),
                         ),
@@ -152,11 +152,11 @@ class _HomeScreenState extends State<HomeScreen> {
                         DataRow(
                           cells: [
                             DataCell(
-                              Text(row.day.toYYYYMMDDString()),
+                              Text(row.day.toYYYYMMDDString(), maxLines: 1),
                             ),
                             for (final cell in row.columns.entries)
                               DataCell(
-                                Text(cell.value.toString()),
+                                Flexible(child: Text(cell.value.toString())),
                               ),
                           ],
                         ),


### PR DESCRIPTION
- Fixes headers & dates flowing into two columns
- Right aligns values

Before:
![image](https://github.com/user-attachments/assets/c30b87d6-1891-4ad9-8af2-c01ca478b316)

After:
![image](https://github.com/user-attachments/assets/c38fbd6c-c42b-49ba-a4ef-9a88c136c3ff)