### PR TITLE
FIX: Magic Pixel Markdown static url

### DIFF
--- a/ffa_app/lib/views/example_syntax_view.dart
+++ b/ffa_app/lib/views/example_syntax_view.dart
@@ -44,7 +44,7 @@ class ExampleSyntaxView extends StatefulWidget {
               title: "Markdown",
               syntax: Syntax.YAML,
               code: """
-![Magic pixel](http://localhost:8080/pixel/sRywXyCwkH1w2X5W/view_github_repo?debug=false)
+![Magic pixel]($url)
 """
             )
           ],


### PR DESCRIPTION
Hey Luke,

I noticed Create Magic Pixel dialog was using a static URL in the Markdown output. I've updated it according to HTML one. Thanks for great and simple project :)

Best Regards,
